### PR TITLE
Fix 'Readme Test' which are actually integration tests. 

### DIFF
--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -44,13 +44,13 @@ jobs:
               }, {
                 inspect_image: 'nothing',
                 os: 'ubuntu-latest',
-                prepare_command: 'docker tag node:12 nothing',
-                build_command: ':',
+                prepare_command: 'docker pull node:12',
+                build_command: 'docker tag node:12 nothing',
               }, {
                 inspect_image: 'nothing',
                 os: 'windows-latest',
-                prepare_command: 'docker tag mcr.microsoft.com/windows/nanoserver:1809 nothing',
-                build_command: ':',
+                prepare_command: 'docker pull mcr.microsoft.com/windows/nanoserver:1809',
+                build_command: 'docker tag mcr.microsoft.com/windows/nanoserver:1809 nothing',
               }, {
                 branch: process.env.GITHUB_REF.replace('refs/heads/', '')
               }

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: Output matrix
       id: set_matrix
-      uses: actions/github-script@v2
+      uses: actions/github-script@v6
       with:
         script: |
           return {
@@ -74,7 +74,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: ${{ matrix.prepare_command }}
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: ${{ matrix.prepare_command }}
 

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -78,7 +78,7 @@ jobs:
 
     - run: ${{ matrix.prepare_command }}
 
-    - uses: jpribyl/action-docker-layer-caching@main
+    - uses: jpribyl/action-docker-layer-caching@main-release
       with:
         key: docker-layer-caching-${{ github.workflow }}-${{ matrix.os }}-${{ matrix.inspect_image }}-sha:${{ github.sha }}-{hash}
         restore-keys: ''
@@ -96,7 +96,7 @@ jobs:
 
     - run: ${{ matrix.prepare_command }}
 
-    - uses: jpribyl/action-docker-layer-caching@main
+    - uses: jpribyl/action-docker-layer-caching@main-release
       with:
         key: never-restored-docker-layer-caching-${{ github.workflow }}-${{ matrix.os }}-${{ matrix.inspect_image }}-sha:${{ github.sha }}-{hash}
         restore-keys: docker-layer-caching-${{ github.workflow }}-${{ matrix.os }}-${{ matrix.inspect_image }}-sha:${{ github.sha }}-

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -4,6 +4,7 @@ on:
   push: 
     branches:
     - master
+  workflow_dispatch:
   schedule:
   - cron: 0 0 */3 * *
 
@@ -77,7 +78,7 @@ jobs:
 
     - run: ${{ matrix.prepare_command }}
 
-    - uses: jpribyl/action-docker-layer-caching@master-release
+    - uses: jpribyl/action-docker-layer-caching@main
       with:
         key: docker-layer-caching-${{ github.workflow }}-${{ matrix.os }}-${{ matrix.inspect_image }}-sha:${{ github.sha }}-{hash}
         restore-keys: ''
@@ -95,7 +96,7 @@ jobs:
 
     - run: ${{ matrix.prepare_command }}
 
-    - uses: jpribyl/action-docker-layer-caching@master-release
+    - uses: jpribyl/action-docker-layer-caching@main
       with:
         key: never-restored-docker-layer-caching-${{ github.workflow }}-${{ matrix.os }}-${{ matrix.inspect_image }}-sha:${{ github.sha }}-{hash}
         restore-keys: docker-layer-caching-${{ github.workflow }}-${{ matrix.os }}-${{ matrix.inspect_image }}-sha:${{ github.sha }}-

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -3,7 +3,7 @@ name: Readme Test
 on:
   push: 
     branches:
-    - master
+    - main
   workflow_dispatch:
   schedule:
   - cron: 0 0 */3 * *

--- a/package.json
+++ b/package.json
@@ -24,6 +24,5 @@
     "ts-node": "10.9.1",
     "ttypescript": "^1.5.13",
     "typescript": "4.9.3"
-  },
-  "type": "module"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "ts-node": "10.9.1",
     "ttypescript": "^1.5.13",
     "typescript": "4.9.3"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
So I had a look at the 'README Test' badge and why it was failing. The name is slightly misleading, it actually seems to be running a set of integration tests.  

![image](https://user-images.githubusercontent.com/746276/205400846-52e6e55a-18eb-4a42-9065-f6fdd9bdfae7.png)

The way it works is, when you push or merge to the `main` branch, the release build pushes to the `main-release` branch. 

https://github.com/jpribyl/action-docker-layer-caching/blob/main/.github/workflows/release.yml#L35-L38

And then the 'Readme Test' action runs against the compiled Javascript in that `main-release` branch.  A bunch of stuff was failing and producing warnings. 

Anyway I _think_ I have it working now, please have a look. 


