### PR TITLE
More robustly clean up

### DIFF
--- a/src/LayerCache.ts
+++ b/src/LayerCache.ts
@@ -278,7 +278,7 @@ class LayerCache {
 
   async cleanUp() {
     if (existsSync(this.getImagesDir())) {
-      await fs.rm(this.getImagesDir(), { recursive: true });
+      await fs.rm(this.getImagesDir(), { recursive: true, force: true });
     }
   }
 


### PR DESCRIPTION
We're encountering the error below, which I believe this change should fix:

```
Layer cache not found: {"id":"fc09430f960d0588cf002ec97c0ff133828d95ffbd5935fa21b0fb643e97269e"}
Error: Layer cache not found: {"id":"fc09430f960d0588cf002ec97c0ff133828d95ffbd5935fa21b0fb643e97269e"}
Some layer cache could not be found. aborting.
/usr/bin/tar -z -xf /home/runner/work/_temp/a62d0129-c3d1-46d0-b375-20e12004b584/cache.tgz -P -C /home/runner/work/asknicelydo/asknicelydo
[Error: ENOTEMPTY: directory not empty, rmdir '/home/runner/work/_actions/jpribyl/action-docker-layer-caching/v0.1.1/dist/ttsc-dist/.adlc/image-layers'] {
  errno: -39,
  code: 'ENOTEMPTY',
  syscall: 'rmdir',
  path: '/home/runner/work/_actions/jpribyl/action-docker-layer-caching/v0.1.1/dist/ttsc-dist/.adlc/image-layers'
}
Error: Error: ENOTEMPTY: directory not empty, rmdir '/home/runner/work/_actions/jpribyl/action-docker-layer-caching/v0.1.1/dist/ttsc-dist/.adlc/image-layers'
```