### PR TITLE
Use Node v20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - uses: actions/checkout@v3
     

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,6 @@ inputs:
     default: 'false'
 
 runs:
-  using: node16
+  using: node20
   main: main.ts
   post: post.ts

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript-is": "^0.19.0"
   },
   "devDependencies": {
-    "@types/node": "18.11.18",
+    "@types/node": "20.11.17",
     "@types/string-format": "^2.0.0",
     "@vercel/ncc": "^0.36.0",
     "ts-node": "10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,10 +215,17 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@18.11.18":
+"@types/node@*":
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+
+"@types/node@20.11.17":
+  version "20.11.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.17.tgz#cdd642d0e62ef3a861f88ddbc2b61e32578a9292"
+  integrity sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/recursive-readdir@^2.2.0":
   version "2.2.1"
@@ -580,6 +587,11 @@ typescript@4.9.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Use Node v20 as runtime, and update types package for node.